### PR TITLE
fix GitHub Pages permalink issue

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -7,7 +7,7 @@ url:              //blog.mgechev.com
 
 # Jekyll configuration
 
-permalink:   /:year/:month/:day/:title
+permalink:   /:year/:month/:day/:title/
 markdown:    redcarpet
 highlighter: pygments
 sass:


### PR DESCRIPTION
Since GitHub upgraded to Jekyll 3 there's a [permalink issue I had on my page as well](https://github.com/juristr/juristr.github.com/commit/d8b631749314aabae82e17e5e3669403f17aa26c#diff-aeb42283af8ef8e9da40ededd3ae2ab2). I just noticed that currently on your site, links with a trailing slash won't work.

Like http://blog.mgechev.com/2016/01/23/angular2-viewchildren-contentchildren-difference-viewproviders/ gives

![image](https://cloud.githubusercontent.com/assets/542458/13777655/c699cf06-eab1-11e5-882a-9b6ce64d67fe.png)

This PR should fix the issue, but better try it locally first (obviously you need to run Jekyll 3 there as well to notice the problem).

Small contribution back for the great work you're doing on the angular2-seed project and styleguide and... :smile: 

---

Btw, also described here: https://jekyllrb.com/docs/upgrading/2-to-3/

![image](https://cloud.githubusercontent.com/assets/542458/13777713/030646d6-eab2-11e5-957f-8e30a865a8e8.png)
