### PR TITLE
fix: add declaration key to tsconfig in AoT example

### DIFF
--- a/_posts/2017-01-21-distributing-an-angular-library-aot-ngc-types.md
+++ b/_posts/2017-01-21-distributing-an-angular-library-aot-ngc-types.md
@@ -281,6 +281,7 @@ Instead, we should precompile our module with `ngc` and enable the `skipTemplate
     "moduleResolution": "node",
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
+    "declaration": true,
     "outDir": "./dist",
     "lib": ["es2015", "dom"]
   },


### PR DESCRIPTION
Thanks for this blog @mgechev .

I think I found an inconsistency, in the examples `tsconfig.json` in the AoT section you mention ` After the last update our tsconfig.json will look like`, but it's missing the key `"declaration": true` added in the section before.

This PR adds it. Cheers B